### PR TITLE
Fix #36 - Remote Debug fails for projects that multi target several frameworks (Error NETSDK1129)

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <add key="xliff-tasks" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+  </packageSources>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+</configuration>

--- a/RaspberryDebugger/DebugHelper.cs
+++ b/RaspberryDebugger/DebugHelper.cs
@@ -381,18 +381,39 @@ windir
 
             try
             {
-                var response = await NeonHelper.ExecuteCaptureAsync(
-                    "dotnet",
-                    new object[]
-                    {
+                ExecuteResponse response;
+
+                if (!string.IsNullOrEmpty(projectProperties.Framework))
+                {
+                    response = await NeonHelper.ExecuteCaptureAsync(
+                        "dotnet",
+                        new object[]
+                        {
+                        "publish",
+                        "--configuration", projectProperties.Configuration,
+                        "--framework", projectProperties.Framework,
+                        "--runtime", projectProperties.Runtime,
+                        "--no-self-contained",
+                        "--output", projectProperties.PublishFolder,
+                        projectProperties.FullPath
+                        },
+                        environmentVariables: environmentVariables).ConfigureAwait(false);
+                }
+                else
+                {
+                    response = await NeonHelper.ExecuteCaptureAsync(
+                        "dotnet",
+                        new object[]
+                        {
                         "publish",
                         "--configuration", projectProperties.Configuration,
                         "--runtime", projectProperties.Runtime,
                         "--no-self-contained",
                         "--output", projectProperties.PublishFolder,
                         projectProperties.FullPath
-                    },
-                    environmentVariables: environmentVariables);
+                        },
+                        environmentVariables: environmentVariables).ConfigureAwait(false);
+                }
 
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/RaspberryDebugger/RaspberryDebugger.csproj
+++ b/RaspberryDebugger/RaspberryDebugger.csproj
@@ -131,11 +131,26 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common">
+      <Version>4.0.0-1.final</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Features">
+      <Version>4.0.0-1.final</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
+      <Version>4.0.0-1.final</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.AppDesigner">
       <Version>15.0.6142705</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces">
       <Version>8.0.50728</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem">
+      <Version>16.2.133-pre</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS">
+      <Version>16.10.0-beta1-10702-01</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities">

--- a/RaspberryDebugger/source.extension.vsixmanifest
+++ b/RaspberryDebugger/source.extension.vsixmanifest
@@ -11,9 +11,7 @@
         <Tags>raspberry pi debugger</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.10,17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
**Fixed #36 - Remote Debug fails for projects that multi target several frameworks (Error NETSDK1129).**

I used `IActiveDebugFrameworkServices` to check for selected framework to pass this to dotnet publish. For single TargetFramework projects this is null, in this case the old command without` --framework` parameter.

Because  `IActiveDebugFrameworkServices`  is not available in stable nuget, I had to add a `nuget.config` with pre-Release feed to fetch the required packages that include this important functionality.