### PR TITLE
Allow Raspberry Pi 2 Zero

### DIFF
--- a/RaspberryDebugger/DebugHelper.cs
+++ b/RaspberryDebugger/DebugHelper.cs
@@ -542,12 +542,13 @@ windir
             // .NET Core only supports Raspberry models 3 and 4.
 
             if (!connection.PiStatus.RaspberryModel.StartsWith("Raspberry Pi 3 Model") &&
-                !connection.PiStatus.RaspberryModel.StartsWith("Raspberry Pi 4 Model"))
+                !connection.PiStatus.RaspberryModel.StartsWith("Raspberry Pi 4 Model") &&
+                !connection.PiStatus.RaspberryModel.StartsWith("Raspberry Pi Zero 2"))
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 MessageBoxEx.Show(
-                    $"Your [{connection.PiStatus.RaspberryModel}] is not supported.  .NET Core requires a Raspberry Model 3 or 4.",
+                    $"Your [{connection.PiStatus.RaspberryModel}] is not supported.  .NET Core requires a Raspberry Model 3, 4 or Pi Zero 2.",
                     $"Raspberry Not Supported",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);


### PR DESCRIPTION
Raspberry Pi 2 Zero is ARMv8 and should work with .net core.

https://github.com/nforgeio/RaspberryDebugger/issues/46